### PR TITLE
feat: version range fallback option

### DIFF
--- a/src/utils/spawn-cmd.ts
+++ b/src/utils/spawn-cmd.ts
@@ -1,20 +1,36 @@
 import { spawn, SpawnOptions } from 'child_process'
 
+// error: could not find `anchor-cli` in registry `crates-io` with version `~0.22`
+const installNotFoundRx = /error\: could not find.+in registry/
+
 /** @private */
 export function spawnCmd(
   cmd: string,
   args: string[],
   options: SpawnOptions = {}
-): Promise<string> {
-  return new Promise((resolve, reject) => {
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let rejected = false
     const child = spawn(cmd, args, options)
-    child.on('error', reject).on('exit', resolve)
+    child
+      .on('error', (err) => {
+        rejected = true
+        reject(err)
+      })
+      .on('exit', () => {
+        if (!rejected) resolve()
+      })
 
-    child.stdout?.on('data', (buf) =>
-      process.stdout.write(buf.toString('utf8'))
-    )
-    child.stderr?.on('data', (buf) =>
-      process.stderr.write(buf.toString('utf8'))
-    )
+    child.stdout?.on('data', (buf) => process.stdout.write(buf))
+    child.stderr?.on('data', (buf) => {
+      const msg = buf.toString()
+      if (installNotFoundRx.test(msg)) {
+        rejected = true
+        child.kill()
+        reject(new Error(msg))
+      } else {
+        process.stderr.write(buf)
+      }
+    })
   })
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -57,3 +57,22 @@ export async function binarySatisfies(
     satisfies: satisfies(binVersion, libVersionRange),
   }
 }
+
+/** @private */
+export function installArgs(
+  binaryCrateName: string,
+  libVersionRange: string,
+  locked: boolean,
+  rootDir: string
+) {
+  return [
+    'install',
+    binaryCrateName,
+    '--version',
+    libVersionRange,
+    ...(locked ? ['--locked'] : []),
+    '--force',
+    '--root',
+    rootDir,
+  ]
+}


### PR DESCRIPTION
When a version fallback range is provided and the install of the binary matching the library
version fails, it attempts the install again with the fallback version.
