### PR TITLE
Replace outdated toml package

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "debug": "^4.3.3",
     "semver": "^7.3.7",
-    "text-table": "^0.2.0",
-    "toml": "^3.0.0"
+    "text-table": "^0.2.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/src/utils/parse-cargo-toml.ts
+++ b/src/utils/parse-cargo-toml.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs'
 import { logError } from './log'
-import { parse } from 'toml'
+import { parse } from '@iarna/toml'
 
 /** @private */
 export type CargoToml = {
@@ -17,7 +17,7 @@ export async function parseCargoToml(fullPath: string) {
     throw err
   }
   try {
-    const parsed: CargoToml = parse(toml)
+    const parsed = parse(toml) as CargoToml
     return { parsed, toml }
   } catch (err) {
     logError('Failed to parse Cargo.toml:\n%s\n%s', toml, err)

--- a/test/fixtures/ah/program/Cargo.toml
+++ b/test/fixtures/ah/program/Cargo.toml
@@ -1,4 +1,6 @@
-[workspace]
+[workspace.dependencies]
+num-traits = "0.2"
+
 [package]
 name = "mpl-auction-house"
 version = "1.1.4"
@@ -23,3 +25,5 @@ default = []
 solana-program = "~1.9.15"
 anchor-lang = "~0.24.1"
 anchor-spl = "~0.24.1"
+
+num-traits.workspace = true


### PR DESCRIPTION
The `toml` package only supports up to version [0.4.0](https://github.com/toml-lang/toml/releases/tag/v0.4.0) of the TOML spec. As of this PR the latest version of the spec is [1.0.0](https://github.com/toml-lang/toml/releases/tag/1.0.0).


An example of a feature missing from `toml` is support for dotted keys. This causes failures when using workspace dependencies.

eg.
```toml
[dependencies]
borsh.workspace = true
```

This PR replaces the outdated `toml` npm package with the `@iarna/toml` package which supports the updated TOML spec.